### PR TITLE
RWA-1309: upgraded spring boot to 2.6.6 due to CVE-2022-22950

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
   id 'pmd'
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.0.11.RELEASE'
-  id 'org.springframework.boot' version '2.6.4'
+  id 'org.springframework.boot' version '2.6.6'
   id 'org.owasp.dependencycheck' version '6.5.3'
   id 'com.github.ben-manes.versions' version '0.38.0'
   id 'org.sonarqube' version '3.2.0'


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RWA-1309


### Change description ###
Upgraded spring boot to 2.6.6 due to CVE-2022-22950


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
