### PR TITLE
RWA-1340: spring boot upgrade due to CVE

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,8 @@ plugins {
   id 'pmd'
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.0.11.RELEASE'
-  id 'org.springframework.boot' version '2.6.6'
-  id 'org.owasp.dependencycheck' version '6.5.3'
+  id 'org.springframework.boot' version '2.6.7'
+  id 'org.owasp.dependencycheck' version '7.1.0.1'
   id 'com.github.ben-manes.versions' version '0.38.0'
   id 'org.sonarqube' version '3.2.0'
   id 'info.solidsoft.pitest' version '1.7.0'
@@ -128,8 +128,8 @@ jacocoTestCoverageVerification {
 jacocoTestReport {
   executionData(test, integration)
   reports {
-    xml.enabled = true
-    csv.enabled = false
+    xml.required = true
+    csv.required = false
     xml.destination file("${buildDir}/reports/jacoco/test/jacocoTestReport.xml")
   }
 }

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -1,44 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-  <suppress until="2022-03-01">
-    <notes><![CDATA[
-     Suppressing as our spring boot version needs to be updated
-   ]]></notes>
-    <cve>CVE-2021-22060</cve>
-  </suppress>
-  <suppress until="2022-03-01">
-    <notes><![CDATA[
-     Suppressing as our spring boot version needs to be updated
-   ]]></notes>
-    <cve>CVE-2018-1258</cve>
-  </suppress>
-  <suppress until="2022-03-01">
-    <notes><![CDATA[
-     Suppressing as our spring security version needs to be updated
-   ]]></notes>
-    <cve>CVE-2021-22112</cve>
-  </suppress>
-  <suppress until="2022-03-01">
-    <notes><![CDATA[
-     Suppressing as our open feign version needs to be updated
-   ]]></notes>
-    <cve>CVE-2021-22044</cve>
-  </suppress>
-  <suppress>
-    <notes><![CDATA[
-     Suppressing as netty http version needs to be updated
-   ]]></notes>
-    <cve>CVE-2021-43797</cve>
-  </suppress>
-  <suppress until="2030-01-01">
-    <cpe>cpe:2.3:a:gradle:gradle:1.7.0:*:*:*:*:*:*:*</cpe>
-    <cve>CVE-2019-11065</cve>
-    <cve>CVE-2019-15052</cve>
-    <cve>CVE-2019-16370</cve>
-    <cve>CVE-2020-11979</cve>
-    <cve>CVE-2021-32751</cve>
-    <cve>CVE-2021-29428</cve>
-    <cve>CVE-2021-29429</cve>
-  </suppress>
 </suppressions>
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RWA-1340


### Change description ###
spring boot upgrade due to CVE
dependencycheck plugin upgrade
removed unnecessary cve supressions


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[ x] No
```
