### PR TITLE
RWA-1844: Upgraded snakeyaml due to cve issues

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,8 @@ plugins {
   id 'pmd'
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.0.11.RELEASE'
-  id 'org.springframework.boot' version '2.7.3'
-  id 'org.owasp.dependencycheck' version '7.1.0.1'
+  id 'org.springframework.boot' version '2.7.4'
+  id 'org.owasp.dependencycheck' version '7.2.1'
   id 'com.github.ben-manes.versions' version '0.38.0'
   id 'org.sonarqube' version '3.2.0'
   id 'info.solidsoft.pitest' version '1.7.0'
@@ -243,8 +243,9 @@ ext.libraries = [
   ]
 ]
 
-//https://nvd.nist.gov/vuln/detail/CVE-2022-25857
-ext['snakeyaml.version'] = '1.31'
+// https://nvd.nist.gov/vuln/detail/CVE-2022-25857
+// https://nvd.nist.gov/vuln/detail/CVE-2022-38751
+ext['snakeyaml.version'] = '1.33'
 
 dependencies {
 

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -22,7 +22,7 @@
    file name: snakeyaml-1.30.jar
    ]]></notes>
     <packageUrl regex="true">^pkg:maven/org\.yaml/snakeyaml@.*$</packageUrl>
-    <cve>CVE-2022-25857</cve>
+    <cve>CVE-2022-38752</cve>
   </suppress>
 </suppressions>
 


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RWA-1844


### Change description ###
Upgraded snakeyaml due to cve issues  and suppressed CVE-2022…-38752 since no fix available yet


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
