### PR TITLE
RWA-2134 - CVE fix 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,8 +4,8 @@ plugins {
   id 'pmd'
   id 'jacoco'
   id 'io.spring.dependency-management' version '1.0.11.RELEASE'
-  id 'org.springframework.boot' version '2.7.4'
-  id 'org.owasp.dependencycheck' version '7.2.1'
+  id 'org.springframework.boot' version '2.7.7'
+  id 'org.owasp.dependencycheck' version '7.4.4'
   id 'com.github.ben-manes.versions' version '0.38.0'
   id 'org.sonarqube' version '3.2.0'
   id 'info.solidsoft.pitest' version '1.7.0'
@@ -231,17 +231,17 @@ def versions = [
   camunda         : '7.14.0',
   pitest          : '1.7.4',
   sonarPitest     : '0.5',
-  tomcat          : '9.0.68'
+  tomcat          : '9.0.69'
 
 ]
 
 ext.libraries = [
   junit5: [
-    "org.junit.jupiter:junit-jupiter-api:${versions.junit}",
-    "org.junit.jupiter:junit-jupiter-engine:${versions.junit}",
-    "org.junit.jupiter:junit-jupiter-params:${versions.junit}",
-    "org.junit.platform:junit-platform-commons:${versions.junitPlatform}",
-    "org.junit.platform:junit-platform-engine:${versions.junitPlatform}"
+    "org.junit.jupiter:junit-jupiter-api:5.9.0",
+    "org.junit.jupiter:junit-jupiter-engine:5.9.0",
+    "org.junit.jupiter:junit-jupiter-params:5.9.0",
+    "org.junit.platform:junit-platform-commons:1.9.0",
+    "org.junit.platform:junit-platform-engine:1.9.0"
   ]
 ]
 
@@ -256,24 +256,24 @@ dependencies {
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-aop'
   implementation group: 'org.springframework.boot', name: 'spring-boot-starter-json'
 
-  implementation group: 'org.springdoc', name: 'springdoc-openapi-ui', version: versions.springDoc
+  implementation group: 'org.springdoc', name: 'springdoc-openapi-ui', version: '1.6.14'
 
   implementation group: 'com.github.hmcts.java-logging', name: 'logging', version: versions.reformLogging
   implementation group: 'com.github.hmcts.java-logging', name: 'logging-appinsights', version: versions.reformLogging
 
-  implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.17.1'
-  implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: '2.17.1'
+  implementation group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.19.0'
+  implementation group: 'org.apache.logging.log4j', name: 'log4j-to-slf4j', version: '2.19.0'
 
-  implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: versions.tomcat
-  implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: versions.tomcat
+  implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-core', version: '10.1.4'
+  implementation group: 'org.apache.tomcat.embed', name: 'tomcat-embed-websocket', version: '10.1.4'
 
-  implementation 'org.camunda.bpm:camunda-external-task-client:7.16.0'
+  implementation 'org.camunda.bpm:camunda-external-task-client:7.17.0'
 
-  annotationProcessor 'org.projectlombok:lombok:1.18.22'
-  compileOnly 'org.projectlombok:lombok:1.18.22'
+  annotationProcessor 'org.projectlombok:lombok:1.18.24'
+  compileOnly 'org.projectlombok:lombok:1.18.24'
 
-  testImplementation group: 'org.pitest', name: 'pitest', version: versions.pitest
-  testImplementation 'info.solidsoft.gradle.pitest:gradle-pitest-plugin:1.7.0'
+  testImplementation group: 'org.pitest', name: 'pitest', version: '1.10.3'
+  testImplementation 'info.solidsoft.gradle.pitest:gradle-pitest-plugin:1.9.11'
 
   testImplementation group: 'org.codehaus.sonar-plugins', name: 'sonar-pitest-plugin', version: versions.sonarPitest
 
@@ -283,10 +283,10 @@ dependencies {
     exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
   }
 
-  testImplementation group: 'org.camunda.bpm.dmn', name: 'camunda-engine-dmn', version: "${versions.camunda}"
-  testImplementation group: 'org.camunda.bpm.assert', name: 'camunda-bpm-assert', version: '8.0.0'
-  testImplementation group: 'org.camunda.bpm', name: 'camunda-engine', version: '7.14.0'
-  testImplementation group: 'com.h2database', name: 'h2', version: '2.1.210'
+  testImplementation group: 'org.camunda.bpm.dmn', name: 'camunda-engine-dmn', version: '7.17.0'
+  testImplementation group: 'org.camunda.bpm.assert', name: 'camunda-bpm-assert', version: '15.0.0'
+  testImplementation group: 'org.camunda.bpm', name: 'camunda-engine', version: '7.17.0'
+  testImplementation group: 'com.h2database', name: 'h2', version: '2.1.214'
 
   integrationTestImplementation sourceSets.main.runtimeClasspath
   integrationTestImplementation sourceSets.test.runtimeClasspath

--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -32,5 +32,23 @@
     <notes>Wait for updates on dependencies</notes>
     <cve>CVE-2021-37533</cve>
   </suppress>
+  <suppress>
+    <notes>
+      org.latencyutils:LatencyUtils:2.0.3 directly used by org.springframework.boot:spring-boot-starter-web 2.7.5 and there are no higher version than LatencyUtils 2.0.3
+    </notes>
+    <cve>CVE-2021-4277</cve>
+  </suppress>
+  <suppress>
+    <notes>
+      org.yaml:snakeyaml:1.33 directly used by org.springframework.boot:spring-boot-starter-web 2.7.5 and there are no higher version then snakeyaml 1.33
+    </notes>
+    <cve>CVE-2022-3064</cve>
+  </suppress>
+  <suppress>
+    <notes>
+      org.yaml:snakeyaml:1.33 directly used by org.springframework.boot:spring-boot-starter-web 2.7.5 and there are no higher version then snakeyaml 1.33
+    </notes>
+    <cve>CVE-2021-4235</cve>
+  </suppress>
 </suppressions>
 


### PR DESCRIPTION
### JIRA link (if applicable) ###

https://tools.hmcts.net/jira/browse/RWA-2134

### Change description ###

CVE fix and upgrade of tomcat 9.0.69, org.owasp.dependencycheck version 7.4.4 and org.springframework.boot version 2.7.7

**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```
